### PR TITLE
Closes #133 - dockable config settings

### DIFF
--- a/TigGUI/Plot/SkyModelPlot.py
+++ b/TigGUI/Plot/SkyModelPlot.py
@@ -1268,6 +1268,7 @@ class SkyModelPlotter(QWidget):
                             geo.moveCenter(QPoint(center.x() + self._dockable_livezoom.width(), geo.y()))
                             self._mainwin.setGeometry(geo)
                 ea_action.setChecked(False)
+        Config.set('livezoom-show', False)
 
     def liveprofile_dockwidget_closed(self):
         list_of_actions = self._menu.actions()
@@ -1283,6 +1284,7 @@ class SkyModelPlotter(QWidget):
                             geo.moveCenter(QPoint(center.x() + self._dockable_liveprofile.width(), geo.y()))
                             self._mainwin.setGeometry(geo)
                 ea_action.setChecked(False)
+        Config.set('liveprofile-show', False)
 
     def liveprofile_dockwidget_toggled(self):
         if self._dockable_liveprofile.isVisible():

--- a/TigGUI/tigger
+++ b/TigGUI/tigger
@@ -146,13 +146,13 @@ def main():
     # max width and height for main window
     max_w, max_h = int(usable_screen.width()*0.9), int(usable_screen.height()*0.88)
     mainwin = TigGUI.MainWindow.MainWindow(None, max_width=max_w, max_height=max_h)
-    # centre on screen
-    centre = QStyle.alignedRect(Qt.LeftToRight, Qt.AlignHCenter, mainwin.size(), QApplication.desktop().availableGeometry())
-    mainwin.setGeometry(centre)
     # set minimum size as the height of image control dialog
     if usable_screen.width() >= 895 <= usable_screen.height():
         mainwin.setMinimumHeight(895)
         mainwin.setMinimumWidth(895)
+    # centre on screen
+    centre = QStyle.alignedRect(Qt.LeftToRight, Qt.AlignHCenter, mainwin.size(), QApplication.desktop().availableGeometry())
+    mainwin.setGeometry(centre)
     # set main window size constraints and policy
     dprint(1, "created main window")
 


### PR DESCRIPTION
Closes #133 - dockable live zoom and live profiles loading upon startup, even though they were closed previously.